### PR TITLE
feat: random pokemon component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,36 @@
 import Image from "next/image";
 import Link from 'next/link'
-
+import { randomId } from '@/lib/utils'
+import RandomPokemon from "../components/randomPokemon";
 export default function Home() {
-  const max = 1000;
-  const min = 1;
-  function randomId(): number {
-   return Math.floor(Math.random() * (max - min) + min);
-  }
   return (
     <main>
       <section className="flex flex-col items-center gap-4 bg-gradient-to-br [background-image:linear-gradient(-10deg,_#C97FE4,_#AECDF6)] p-14">
         <h1 className="text-center mt-14 text-8xl font-extrabold text-transparent bg-gradient-to-r from-purple-800 to-blue-800 [background-clip:text]">Gotta catch 'em all!</h1>
         <p className="text-center text-white text-xl">Discover, search and explore the amazing world of Pokémon. Find<br /> your favourite and learn about their stats.</p>
-        <Link href={`single/${randomId()}`}>        
-        <button className="btn-primary">
-          <Image
-            src="/Dice.svg"
-            width={25}
-            height={25}
-            alt="Dice"
+        <Link href={`single/${randomId()}`}>
+          <button className="btn-primary">
+            <Image
+              src="/Dice.svg"
+              width={25}
+              height={25}
+              alt="Dice"
             />
-          Random Pokémon</button>
-            </Link>
+            Random Pokémon</button>
+        </Link>
+      </section>
+      <section className="text-center">
+        <h2 className="text-4xl m-12">Featured Pokemon</h2>
+        <ul className="flex justify-evenly">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i}>
+              < RandomPokemon />
+            </li>
+          ))}
+
+
+        </ul>
+
       </section>
     </main>
   );

--- a/app/single/[id]/page.tsx
+++ b/app/single/[id]/page.tsx
@@ -1,53 +1,13 @@
 import { notFound } from 'next/navigation';
-import Image from 'next/image';
-import RoundedImageFrame from '@/app/components/roundedImageFrame';
-import { getTypeColor } from '@/lib/pokemonColors';
+import PokemonCard from '@/components/pokemonCard';
+import { fetchPokemon } from '@/lib/utils';
 export default async function singlePokemon({ params }: { params: Promise<{ id: number }> }) {
+
   const searchId = (await params).id;
+  const pokemon = await fetchPokemon(searchId);
 
-  const pokeRes = await fetch(`https://pokeapi.co/api/v2/pokemon/${searchId}`);
-  const singlePokemon = await pokeRes.json();
-  const { name, id, types, stats } = singlePokemon;
-
-/*   const speciesRes = await fetch(`https://pokeapi.co/api/v2/pokemon-species/${searchId}`);
-  const speciesInfo = await speciesRes.json();
-  const { color: {name:colorName} } = speciesInfo; */
-
-
-  if (!name) notFound();
+  if (!pokemon) notFound();
   return (
-    <div className="border-8 border-blue-300 p-8 w-[25rem] flex flex-col items-center">
-      <RoundedImageFrame type={types[0].type.name}>
-
-      <Image
-      className=''
-        src={singlePokemon.sprites.front_default}
-        height="300"
-        width="300"
-        alt={singlePokemon.name}
-      ></Image>
-      </RoundedImageFrame>
-      <p>#{id}</p>
-      <h1>{singlePokemon.name}</h1>
-      <ul>
-        {types.map((item: { slot: string; type: { name: string } }) => {
-          return <li key={item.slot} style={{backgroundColor: getTypeColor(item.type.name)}} className='text-white p-2 rounded-xl'>{item.type.name}</li>;
-        })}
-      </ul>
-      <ul>
-        {stats.map(
-          (item: { base_stat: number; effort: number; stat: { name: string; url: string } }) => {
-            if ([ 'hp','attack', 'defense'].includes(item.stat.name)) {
-              return (
-                <li key={item.stat.name}>
-                  <span>{item.stat.name}</span>
-                  <span>{item.base_stat}</span>
-                </li>
-              );
-            }
-          }
-        )}
-      </ul>
-    </div>
+    <PokemonCard pokemon={pokemon}></PokemonCard>
   );
 }

--- a/components/pokemonCard.tsx
+++ b/components/pokemonCard.tsx
@@ -1,0 +1,42 @@
+import { Pokemon } from "../types/pokemon";
+import Image from "next/image";
+import RoundedImageFrame from "./roundedImageFrame";
+import { getTypeColor } from "@/lib/pokemonColors";
+export default function PokemonCard({ pokemon }: { pokemon: Pokemon }) {
+
+    const { types, sprites, name, stats, id } = pokemon;
+    return (
+        <div className="border-8 border-blue-300 p-8 w-[25rem] flex flex-col items-center rounded-xl bg-[#F1FDFF]">
+            <RoundedImageFrame type={types[0].type.name}>
+
+                <Image
+                    className=''
+                    src={sprites.front_default}
+                    height="300"
+                    width="300"
+                    alt={name}
+                ></Image>
+            </RoundedImageFrame>
+            <p>#{id}</p>
+            <h1>{name}</h1>
+            <ul className="flex">
+                {types.map((item: { slot: number; type: { name: string } }) => {
+                    return <li key={item.slot} style={{ backgroundColor: getTypeColor(item.type.name) }} className='text-white p-2 rounded-xl'>{item.type.name}</li>;
+                })}
+            </ul>
+            <ul>
+                {stats.map((item: Pokemon['stats'][number]) => {
+                    if (['hp', 'attack', 'defense'].includes(item.stat.name)) {
+                        return (
+                            <li key={item.stat.name}>
+                                <span>{item.stat.name}</span>
+                                <span>{item.base_stat}</span>
+                            </li>
+                        );
+                    }
+                }
+                )}
+            </ul>
+        </div>
+    )
+}

--- a/components/randomPokemon.tsx
+++ b/components/randomPokemon.tsx
@@ -1,0 +1,13 @@
+import { fetchPokemon, randomId } from "@/lib/utils";
+import PokemonCard from "./pokemonCard";
+
+export default async function randomPokemon() {
+
+    const id = randomId();
+    const pokemon = await fetchPokemon(id)
+
+    return (
+        <PokemonCard pokemon={pokemon}></PokemonCard>
+    )
+
+}

--- a/components/roundedImageFrame.tsx
+++ b/components/roundedImageFrame.tsx
@@ -4,9 +4,8 @@ export default function RoundedImageFrame({ children, type }: { children: React.
     
     const color = getTypeColor(type);
 
-
     return (
-        <div className="border-8 rounded-full"
+        <div className="border-8 rounded-full bg-white"
             style={{ borderColor: color }}>
             {children}
         </div >

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,17 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { Pokemon } from "@/types/pokemon";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function randomId(min: number = 0, max: number = 1000): number {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+
+export async function fetchPokemon(id: number): Pokemon {
+  const pokeRes = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
+  return await pokeRes.json();
 }

--- a/types/pokemon.ts
+++ b/types/pokemon.ts
@@ -1,0 +1,19 @@
+export type Pokemon = {
+    name: string;
+    id: number;
+    stats: {
+        base_stat: number;
+        stat: {
+            name: string;
+        };
+    }[];
+    types: {
+        slot: number;
+        type: {
+            name: string;
+        };
+    }[];
+    sprites: {
+        front_default: string;
+    };
+};


### PR DESCRIPTION
What’s changed

Leveraged Array.from({ length: 4 }) (or similar logic) to generate an array for mapping and rendering multiple Pokémon components.

Each PokémonCard now receives a unique key to ensure React list rendering remains stable.

Adjusted layout styles to accommodate the array of Pokémon cards—e.g., using flex layout with wrapping or grid for responsive alignment.

Ensured that the randomization logic runs on mount or on user-triggered action (e.g., a “Shuffle” button can be easily added later).